### PR TITLE
error page displayed when attempting to deactivate only admin

### DIFF
--- a/TabloidMVC/Models/ViewModels/UserProfileEditViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/UserProfileEditViewModel.cs
@@ -6,5 +6,6 @@ namespace TabloidMVC.Models.ViewModels
     {
         public UserProfile UserProfile { get; set; }
         public List<UserType> UserTypes { get; set; }
+        public bool IsSafeToEditUserType { get; set; }
     }
 }

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -7,6 +7,7 @@ namespace TabloidMVC.Repositories
     {
         UserProfile GetByEmail(string email);
         List<UserProfile> GetUsers();
+        List<UserProfile> GetAdmins();
         UserProfile GetUserById(int userId);
         void UpdateUser(UserProfile user);
         void Add(UserProfile newUser);

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -97,6 +97,45 @@ namespace TabloidMVC.Repositories
             }
         }
 
+        public List<UserProfile> GetAdmins() 
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                    SELECT
+                    UserProfile.Id 'ID',
+                    FirstName,
+                    LastName,
+                    DisplayName,
+                    Email,
+                    ImageLocation,
+                    CreateDateTime,
+                    Activated,
+                    UserTypeId,
+                    UserType.Name 'User Type'
+                    FROM UserProfile
+                    LEFT JOIN UserType
+                    ON UserProfile.UserTypeId = UserType.Id
+                    WHERE Activated = 1 AND UserType.Name = 'Admin'
+                    ";
+
+                    using (SqlDataReader reader = cmd.ExecuteReader())
+                    {
+                        List<UserProfile> users = new List<UserProfile>();
+
+                        while (reader.Read())
+                        {
+                            users.Add(NewUserFromReader(reader));
+                        }
+                        return users;
+                    }
+                }
+            }
+        }
+
         public List<UserProfile> GetDeactivatedUsers()
         {
             using (var conn = Connection)

--- a/TabloidMVC/Views/Account/Edit.cshtml
+++ b/TabloidMVC/Views/Account/Edit.cshtml
@@ -13,6 +13,7 @@
         <form asp-action="Edit">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 <input asp-for="@Model.UserProfile.Id" type="hidden" />
+                <input asp-for="@Model.IsSafeToEditUserType" type="hidden" />
             <div class="form-group">
                 <label asp-for="@Model.UserProfile.FirstName" class="control-label"></label>
                 <input asp-for="@Model.UserProfile.FirstName" class="form-control" />

--- a/TabloidMVC/Views/Account/LastAdminError.cshtml
+++ b/TabloidMVC/Views/Account/LastAdminError.cshtml
@@ -1,0 +1,13 @@
+﻿
+@{
+    ViewData["Title"] = "LastAdminError";
+}
+
+<h1>Error: Cannot deactivate only system admin</h1>
+<p>This is the only administrator.  You must assign a new administrator 
+    before deactivating, deleting, or changing the role of the current administrator.</p>
+
+<div>
+    <a asp-action="Index" class="m-5">Back to List</a>
+</div>
+


### PR DESCRIPTION
closes #20 

Prevents the loss of only admin by deactivating or switching roles.

created new account controller action and view for LastAdminError.
made changes to Edit action to prevent inappropriate role switching
Added new property to UserProfileEditViewModel to prevent inappropriate role switching.
Added a new method to UserProfileRepo which lists all admins.
Made changes to Deactivate action to prevent deactivating final admin.

Tested by attempting to deactivate only admin, change only admin role, adding a new admin and then making them the only admin and attempting again.  